### PR TITLE
No comma premodifiers

### DIFF
--- a/src/main/java/simplenlg/features/LexicalFeature.java
+++ b/src/main/java/simplenlg/features/LexicalFeature.java
@@ -584,6 +584,41 @@ public abstract class LexicalFeature {
 
 	/**
 	 * <p>
+	 * This flag determines if the comma must be ommited before a coordination conjunction,
+	 * after a front modifier or after a pre-modifier.
+	 * </p>
+	 * <table border="1">
+	 * <tr>
+	 * <td><b>Feature name</b></td>
+	 * <td><em>no_comma</em></td>
+	 * </tr>
+	 * <tr>
+	 * <td><b>Expected type</b></td>
+	 * <td><code>Boolean</code></td>
+	 * </tr>
+	 * <tr>
+	 * <td><b>Created by</b></td>
+	 * <td>The information is read from Lexicons that support this feature
+	 * and can be set by the user.</td>
+	 * </tr>
+	 * <tr>
+	 * <td><b>Used by</b></td>
+	 * <td>The orthography methods.</td>
+	 * </tr>
+	 * <tr>
+	 * <td><b>Applies to</b></td>
+	 * <td>Conjunctions and word that are or can be front modifiers or pre-modifiers.</td>
+	 * </tr>
+	 * <tr>
+	 * <td><b>Default</b></td>
+	 * <td><code>Boolean.FALSE</code>.</td>
+	 * </tr>
+	 * </table>
+	 */
+	public static final String NO_COMMA = "no_comma";
+
+	/**
+	 * <p>
 	 * This feature gives the past tense form of a verb. For example, the past
 	 * tense of <em>eat</em> is <em>ate</em>, the past tense of <em>walk</em> is
 	 * <em>walked</em>.

--- a/src/main/java/simplenlg/features/french/FrenchLexicalFeature.java
+++ b/src/main/java/simplenlg/features/french/FrenchLexicalFeature.java
@@ -353,42 +353,7 @@ public abstract class FrenchLexicalFeature {
 	 * </table>
 	 */
 	public static final String CLITIC_RISING = "clitic_rising";
-	
-	/**
-	 * <p>
-	 * This flag determines if the comma must be ommited before a coordination conjunction
-	 * or after a front modifier.
-	 * </p>
-	 * <table border="1">
-	 * <tr>
-	 * <td><b>Feature name</b></td>
-	 * <td><em>no_comma</em></td>
-	 * </tr>
-	 * <tr>
-	 * <td><b>Expected type</b></td>
-	 * <td><code>Boolean</code></td>
-	 * </tr>
-	 * <tr>
-	 * <td><b>Created by</b></td>
-	 * <td>The information is read from Lexicons that support this feature
-	 * and can be set by the user.</td>
-	 * </tr>
-	 * <tr>
-	 * <td><b>Used by</b></td>
-	 * <td>The orthography methods.</td>
-	 * </tr>
-	 * <tr>
-	 * <td><b>Applies to</b></td>
-	 * <td>Conjunctions and word that are or can be front modifiers.</td>
-	 * </tr>
-	 * <tr>
-	 * <td><b>Default</b></td>
-	 * <td><code>Boolean.FALSE</code>.</td>
-	 * </tr>
-	 * </table>
-	 */
-	public static final String NO_COMMA = "no_comma";
-	
+
 	/**
 	 * <p>
 	 * This flag determines if the coordination conjunction must be repeated before each

--- a/src/main/java/simplenlg/orthography/english/OrthographyHelper.java
+++ b/src/main/java/simplenlg/orthography/english/OrthographyHelper.java
@@ -22,6 +22,7 @@ import java.util.List;
 
 import simplenlg.features.DiscourseFunction;
 import simplenlg.features.InternalFeature;
+import simplenlg.features.LexicalFeature;
 import simplenlg.framework.DocumentElement;
 import simplenlg.framework.ElementCategory;
 import simplenlg.framework.ListElement;
@@ -73,7 +74,9 @@ public class OrthographyHelper implements OrthographyHelperInterface {
 			Object function = children.isEmpty() ? null : children.get(0)
 					.getFeature(InternalFeature.DISCOURSE_FUNCTION);
 
-			if (DiscourseFunction.PRE_MODIFIER.equals(function)) {
+            if (!children.isEmpty()
+                    && DiscourseFunction.PRE_MODIFIER.equals(children.get(0).getFeature(InternalFeature.DISCOURSE_FUNCTION))
+                    && !children.get(0).getFeatureAsBoolean(LexicalFeature.NO_COMMA)) {
 				realiseList(buffer, element.getChildren(), ",");
 			} else {
 				realiseList(buffer, element.getChildren(), "");

--- a/src/main/java/simplenlg/orthography/english/OrthographyProcessor.java
+++ b/src/main/java/simplenlg/orthography/english/OrthographyProcessor.java
@@ -55,12 +55,37 @@ import simplenlg.framework.StringElement;
  */
 public class OrthographyProcessor extends NLGModule {
 
-	@Override
+    private boolean commaSepPremodifiers; // set whether to separate
+                                          // premodifiers using commas
+
+    @Override
 	public void initialise() {
-		// No initialisation.
+        this.commaSepPremodifiers = true;
 	}
 
-	@Override
+    /**
+     * Check whether this processor separates premodifiers using a comma.
+     *
+     * @return <code>true</code> if premodifiers in the noun phrase are
+     *         comma-separated.
+     */
+    public boolean isCommaSepPremodifiers() {
+        return commaSepPremodifiers;
+    }
+
+    /**
+     * Set whether to separate premodifiers using a comma. If <code>true</code>,
+     * premodifiers will be comma-separated, as in <i>the long, dark road</i>.
+     * If <code>false</code>, they won't.
+     *
+     * @param commaSepPremodifiers
+     *            the commaSepPremodifiers to set
+     */
+    public void setCommaSepPremodifiers(boolean commaSepPremodifiers) {
+        this.commaSepPremodifiers = commaSepPremodifiers;
+    }
+
+    @Override
 	public NLGElement realise(NLGElement element) {
 		NLGElement realisedElement = null;
 
@@ -102,7 +127,7 @@ public class OrthographyProcessor extends NLGModule {
 						.getFeature(InternalFeature.DISCOURSE_FUNCTION);
 
 				if (DiscourseFunction.PRE_MODIFIER.equals(function)) {
-					realiseList(buffer, element.getChildren(), ",");
+                    realiseList(buffer, element.getChildren(), this.commaSepPremodifiers ? "," : "");
 				} else {
 					realiseList(buffer, element.getChildren(), "");
 				}

--- a/src/main/java/simplenlg/orthography/french/OrthographyHelper.java
+++ b/src/main/java/simplenlg/orthography/french/OrthographyHelper.java
@@ -20,10 +20,7 @@ package simplenlg.orthography.french;
 
 import java.util.List;
 
-import simplenlg.features.DiscourseFunction;
-import simplenlg.features.Feature;
-import simplenlg.features.Form;
-import simplenlg.features.InternalFeature;
+import simplenlg.features.*;
 import simplenlg.features.french.FrenchLexicalFeature;
 import simplenlg.features.french.FrenchInternalFeature;
 import simplenlg.framework.ElementCategory;
@@ -78,7 +75,7 @@ public class OrthographyHelper extends simplenlg.orthography.english.Orthography
 					realisation.append(", "); //$NON-NLS-1$
 				} else {
 					// for conjunctions other than "et" and "ou"
-					if (!realisedChild.getFeatureAsBoolean(FrenchLexicalFeature.NO_COMMA)) {
+					if (!realisedChild.getFeatureAsBoolean(LexicalFeature.NO_COMMA)) {
 					realisation.append(", "); //$NON-NLS-1$
 					}
 					realisedChild = realisedChild.realiseOrthography();
@@ -151,7 +148,7 @@ public class OrthographyHelper extends simplenlg.orthography.english.Orthography
 
 				if ( !separatorAdded && (DiscourseFunction.FRONT_MODIFIER.equals(function)
 							|| DiscourseFunction.CUE_PHRASE.equals(function))
-						&& !thisElement.getFeatureAsBoolean(FrenchLexicalFeature.NO_COMMA)) {
+						&& !thisElement.getFeatureAsBoolean(LexicalFeature.NO_COMMA)) {
 					realisation.append(",");
 					separatorAdded = true;
 				}

--- a/src/main/java/simplenlg/realiser/english/Realiser.java
+++ b/src/main/java/simplenlg/realiser/english/Realiser.java
@@ -59,6 +59,38 @@ public class Realiser extends NLGModule {
 		setLexicon(lexicon);
 	}
 
+    /**
+     * Check whether this processor separates premodifiers using a comma.
+     *
+     * <br/>
+     * <strong>Implementation note:</strong> this method checks whether the
+     * {@link simplenlg.orthography.english.OrthographyProcessor} has the
+     * parameter set.
+     *
+     * @return <code>true</code> if premodifiers in the noun phrase are
+     *         comma-separated.
+     */
+    public boolean isCommaSepPremodifiers() {
+        return this.orthography == null ? false : this.orthography.isCommaSepPremodifiers();
+    }
+
+    /**
+     * Set whether to separate premodifiers using a comma. If <code>true</code>,
+     * premodifiers will be comma-separated, as in <i>the long, dark road</i>.
+     * If <code>false</code>, they won't. <br/>
+     * <strong>Implementation note:</strong>: this method sets the relevant
+     * parameter in the
+     * {@link simplenlg.orthography.english.OrthographyProcessor}.
+     *
+     * @param commaSepPremodifiers
+     *            the commaSepPremodifiers to set
+     */
+    public void setCommaSepPremodifiers(boolean commaSepPremodifiers) {
+        if(this.orthography != null) {
+            this.orthography.setCommaSepPremodifiers(commaSepPremodifiers);
+        }
+    }
+
 	@Override
 	public void initialise() {
 		this.morphology = new MorphologyProcessor();

--- a/src/test/java/simplenlg/test/AdjectivePhraseTest.java
+++ b/src/test/java/simplenlg/test/AdjectivePhraseTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 
 import simplenlg.features.Feature;
 import simplenlg.framework.CoordinatedPhraseElement;
+import simplenlg.framework.LexicalCategory;
 import simplenlg.framework.PhraseElement;
 import simplenlg.framework.StringElement;
 
@@ -121,4 +122,24 @@ public class AdjectivePhraseTest extends SimpleNLG4Test {
 				sent).getRealisation());
 
 	}
+
+    /**
+     * Test for multiple adjective modifiers with comma-separation. Example courtesy of William Bradshaw (Data2Text Ltd).
+     */
+    @Test
+    public void testMultipleModifiers() {
+        PhraseElement np = this.phraseFactory
+                .createNounPhrase(this.lexicon.getWord("message",
+                        LexicalCategory.NOUN));
+        np.addPreModifier(this.lexicon.getWord("active",
+                LexicalCategory.ADJECTIVE));
+        np.addPreModifier(this.lexicon.getWord("temperature",
+                LexicalCategory.ADJECTIVE));
+        Assert.assertEquals("active, temperature message", this.realiser.realise(np).getRealisation());
+
+        //now we set the realiser not to separate using commas
+        this.realiser.setCommaSepPremodifiers(false);
+        Assert.assertEquals("active temperature message", this.realiser.realise(np).getRealisation());
+
+    }
 }

--- a/src/test/java/simplenlg/test/english/AdjectivePhraseTest.java
+++ b/src/test/java/simplenlg/test/english/AdjectivePhraseTest.java
@@ -23,6 +23,7 @@ import junit.framework.Assert;
 import org.junit.Test;
 
 import simplenlg.features.Feature;
+import simplenlg.features.LexicalFeature;
 import simplenlg.framework.CoordinatedPhraseElement;
 import simplenlg.framework.PhraseElement;
 import simplenlg.framework.StringElement;
@@ -128,5 +129,22 @@ public class AdjectivePhraseTest extends SimpleNLG4TestBase {
 		Assert.assertEquals("John very quickly eats", this.realiser.realise( //$NON-NLS-1$
 				sent).getRealisation());
 
+	}
+
+	/**
+	 * Test for multiple adjective pre-modifiers with and without comma-separation.
+	 */
+	@Test
+	public void testMultipleModifiers() {
+		PhraseElement np = this.phraseFactory.createNounPhrase("the", "boat");
+		WordElement big = this.lexicon.getWord("big", LexicalCategory.ADJECTIVE);
+		np.addPreModifier(big);
+		WordElement beautiful = this.lexicon.getWord("beautiful", LexicalCategory.ADJECTIVE);
+		np.addPreModifier(beautiful);
+		Assert.assertEquals("the big, beautiful boat", this.realiser.realise(np).getRealisation());
+
+		//now we set the realiser not to separate using commas
+		big.setFeature(LexicalFeature.NO_COMMA, true);
+		Assert.assertEquals("the big beautiful boat", this.realiser.realise(np).getRealisation());
 	}
 }

--- a/src/test/java/simplenlg/test/french/AdjectivePhraseTest.java
+++ b/src/test/java/simplenlg/test/french/AdjectivePhraseTest.java
@@ -23,6 +23,7 @@ import junit.framework.Assert;
 import org.junit.Test;
 
 import simplenlg.features.Feature;
+import simplenlg.features.LexicalFeature;
 import simplenlg.features.Tense;
 import simplenlg.framework.CoordinatedPhraseElement;
 import simplenlg.framework.PhraseElement;
@@ -152,5 +153,19 @@ public class AdjectivePhraseTest extends SimpleNLG4TestBase {
 		sent.addFrontModifier("fort");
 		Assert.assertEquals("fort, les chiennes ont jappé", //$NON-NLS-1$
 				this.realiser.realise(sent).getRealisation());
+	}
+
+	/**
+	 * Test for multiple adjective pre-modifiers without comma-separation. For symmetry with {@link simplenlg.test.english.AdjectivePhraseTest#testMultipleModifiers()}
+	 */
+	@Test
+	public void testMultipleModifiers() {
+		PhraseElement np = this.factory.createNounPhrase("le", "bateau");
+		WordElement beau = this.lexicon.getWord("beau", LexicalCategory.ADJECTIVE);
+		np.addPreModifier(beau);
+		WordElement grand = this.lexicon.getWord("grand", LexicalCategory.ADJECTIVE);
+		np.addPreModifier(grand);
+		Assert.assertEquals("le beau grand bateau", this.realiser.realise(np).getRealisation());
+
 	}
 }

--- a/src/test/java/simplenlg/test/french/ClauseTest.java
+++ b/src/test/java/simplenlg/test/french/ClauseTest.java
@@ -141,14 +141,14 @@ public class ClauseTest extends SimpleNLG4TestBase {
 						this.realiser.realise(this.s4).getRealisation());
 		
 		// without comma
-		this.s4.getFeatureAsElement(Feature.CUE_PHRASE).setFeature(FrenchLexicalFeature.NO_COMMA, true);
-		this.s4.getFrontModifiers().get(0).setFeature(FrenchLexicalFeature.NO_COMMA, true);
+		this.s4.getFeatureAsElement(Feature.CUE_PHRASE).setFeature(LexicalFeature.NO_COMMA, true);
+		this.s4.getFrontModifiers().get(0).setFeature(LexicalFeature.NO_COMMA, true);
 		Assert
 		.assertEquals(
 				"cependant demain Jane et André ramasseront les balles dans le magasin", //$NON-NLS-1$
 				this.realiser.realise(this.s4).getRealisation());
-		this.s4.getFeatureAsElement(Feature.CUE_PHRASE).setFeature(FrenchLexicalFeature.NO_COMMA, false);
-		this.s4.getFrontModifiers().get(0).setFeature(FrenchLexicalFeature.NO_COMMA, false);
+		this.s4.getFeatureAsElement(Feature.CUE_PHRASE).setFeature(LexicalFeature.NO_COMMA, false);
+		this.s4.getFrontModifiers().get(0).setFeature(LexicalFeature.NO_COMMA, false);
 	}
 
 	/**
@@ -456,7 +456,7 @@ public class ClauseTest extends SimpleNLG4TestBase {
 		SPhraseSpec avoir = factory.createClause("tu", "avoir", temps);
 		avoir.setFeature(Feature.TENSE, Tense.FUTURE);
 		avoir.addFrontModifier(partir);
-		partir.setFeature(FrenchLexicalFeature.NO_COMMA, true);
+		partir.setFeature(LexicalFeature.NO_COMMA, true);
 		AdvPhraseSpec temporalAdverb = factory.createAdverbPhrase("demain");
 		avoir.addFrontModifier(temporalAdverb);
 		Assert.assertEquals( "quand tu partiras demain, tu auras du beau temps",


### PR DESCRIPTION
In EnFr realisation mode (with `OrthographyHelper`s), The NO_COMMA feature has been reused for english language and can be used on pre-modifiers to remove the comma separator when multiple.

In original realisation mode, the `commaSepPremodifiers` option has been copied as-is from the SimpleNLG project.

Closes #13.