### PR TITLE
Lexicon correction for the *faux* adjective

### DIFF
--- a/src/main/resources/default-french-lexicon.xml
+++ b/src/main/resources/default-french-lexicon.xml
@@ -11794,6 +11794,8 @@
 		<category>adjective</category>
 		<id>faux_3</id>
 		<plural>faux</plural>
+		<feminine_singular>fausse</feminine_singular>
+		<feminine_plural>fausses</feminine_plural>
 	</word>
 	<word>
 		<base>faveur</base>


### PR DESCRIPTION
A correction to the default french lexicon : missing feminine and plural inflections.